### PR TITLE
Fix the synonyms + add locale

### DIFF
--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -11,5 +11,6 @@
     "functionScore": "Skor Function",
     "synonyms": "Sinonim",
     "dataAndIndexes": "Data & Indeks",
-    "collection_name": "restaurants_id"
+    "collection_name": "restaurants_id",
+    "synonyms_name": "menu_synonyms_id"
 }

--- a/src/pages/SynonymsPage.js
+++ b/src/pages/SynonymsPage.js
@@ -8,6 +8,7 @@ import Icon from "../images/whatscooking.png";
 import IdeasIcon from "../images/foodIdeas.png";
 import SYNCOL from "../images/SynonymCol.png";
 import DocHero from "../images/DocModelHero.JPG";
+import { useTranslation } from 'react-i18next';
 
 const { REACT_APP_GETSYNONYMS_SECRET } = process.env;
 
@@ -17,11 +18,13 @@ const SynonymsPage = () => {
   const [submissionMessage, setSubmissionMessage] = useState("");
   const [deleteMessage, setDeleteMessage] = useState("");
   const [updateMessage, setUpdateMessage] = useState("");
+  
+  const { t } = useTranslation();
 
   const getSynonyms = async () => {
     let storedSynonyms = await (
       await fetch(
-        `https://ap-southeast-1.aws.data.mongodb-api.com/app/whatscooking-XXXXX/endpoint/synonyms/getFoodSynonyms`
+        "https://ap-southeast-1.aws.data.mongodb-api.com/app/application-1-rgjfz/endpoint/synonyms/getFoodSynonyms?synonyms="+ t('synonyms_name')
       )
     ).json();
     setLoadedSynonyms(storedSynonyms.foodSynonyms);


### PR DESCRIPTION
Fix the synonyms page 
Modifying the functions getFoodSynonyms to accept GET request to find appropriate collection name
https://ap-southeast-1.aws.data.mongodb-api.com/app/application-1-rgjfz/endpoint/synonyms/getFoodSynonyms?synonyms=menu_synonyms_id 

Add locale to SynonymsPage 