### PR TITLE
Change locale colnames

### DIFF
--- a/appservice/functions/getFacets.js
+++ b/appservice/functions/getFacets.js
@@ -16,7 +16,7 @@ exports = async function(payload, response) {
     console.log(JSON.stringify(searchParameters));
     
      
-    let{ searchTerm, food, operator, dist, stars, borough, cuisine, collection_name, lng, lat } = searchParameters;
+    let{ searchTerm, food, operator, dist, stars, borough, cuisine, locale, lng, lat } = searchParameters;
 
     if (lng === undefined || lat === undefined) {
       lng = -73.98474;
@@ -26,7 +26,7 @@ exports = async function(payload, response) {
     }
       
     // Querying a mongodb collection:
-    const collection = context.services.get("mongodb-atlas").db("whatscooking").collection(collection_name);
+    const collection = context.services.get("mongodb-atlas").db("whatscooking").collection("restaurants_" + locale);
     
     let pathArray = ["name", "cuisine"];
     let distance = 1609;

--- a/appservice/functions/getFoodSynonyms.js
+++ b/appservice/functions/getFoodSynonyms.js
@@ -3,10 +3,12 @@ exports = async function(payload, response) {
   console.log("Returning all food synonyms");
  
 
+  let synonyms = payload.query.synonyms;
+  let locale = payload.query.locale;
   // Querying a mongodb service:
-  const collection = context.services.get("mongodb-atlas").db("whatscooking").collection("menu_synonyms");
+  const collection = context.services.get("mongodb-atlas").db("whatscooking").collection('menu_synonyms_' + locale);
   
-  const foodSynonyms = await collection.find({}).toArray();
+  const foodSynonyms = await collection.find({'synonyms':synonyms}).toArray();
   
 
  return {foodSynonyms, ok:true};

--- a/appservice/functions/getRestaurants.js
+++ b/appservice/functions/getRestaurants.js
@@ -10,7 +10,7 @@ exports = async function(payload, response) {
 
       let searchParameters = EJSON.parse(payload.body.text());
       console.log(JSON.stringify(searchParameters));
-      let { searchTerm, food, operator, functionScore, dist, borough, stars, cuisine, collection_name, lng, lat } = searchParameters;
+      let { searchTerm, food, operator, functionScore, dist, borough, stars, cuisine, locale, lng, lat } = searchParameters;
 
       if (lng === undefined || lat === undefined) {
         lng = -73.98474;
@@ -20,7 +20,7 @@ exports = async function(payload, response) {
       }
 
       // Querying a mongodb collection:
-      const collection = context.services.get("mongodb-atlas").db("whatscooking").collection(collection_name);
+      const collection = context.services.get("mongodb-atlas").db("whatscooking").collection('restaurants_' + locale);
 
        // EMPTY SEARCH
       if (!searchTerm && !food && (operator==="text") && (cuisine.length===0) && (stars ===1)){   // added && (stars ===1) Jan 3

--- a/appservice/functions/getRestaurantsAutocomplete.js
+++ b/appservice/functions/getRestaurantsAutocomplete.js
@@ -1,9 +1,9 @@
 exports = async function(payload){
    
   let restname = payload.query.restname;
-  let collection_name = payload.query.collection_name;
+  let locale = payload.query.locale;
  
-  const collection = context.services.get("mongodb-atlas").db("whatscooking").collection(collection_name);
+  const collection = context.services.get("mongodb-atlas").db("whatscooking").collection("restaurants_" + locale);
   
   //aggregation array
   let calledAggregation = [

--- a/data/synonyms/whatscooking.menu_synonyms.json
+++ b/data/synonyms/whatscooking.menu_synonyms.json
@@ -1,0 +1,110 @@
+[{
+  "_id": {
+    "$oid": "617f3b42ade8e71c16489dbe"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "burger",
+    "burgers",
+    "hamburger",
+    "hamburgers",
+    "cheeseburger",
+    "cheeseburgers"
+  ],
+  "date_inserted": null,
+  "date_updated": {
+    "$date": "2021-11-15T00:33:50.573Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b7d834053fed8281c1ac6"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "pasta"
+  ],
+  "synonyms": [
+    "spaghetti",
+    "macaroni",
+    "fettuccine",
+    "cappellini",
+    "ravioli",
+    "rigatoni",
+    "linguine",
+    "penne",
+    "ziti",
+    "tortellini",
+    "tagliatelle",
+    "lasagna",
+    "lasagne",
+    "manicotti"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac3"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "shawarma",
+    "gyros"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "6268a01b5899f60be615cb66"
+  },
+  "input": [
+    "noodles"
+  ],
+  "mappingType": "explicit",
+  "synonyms": [
+    "lo mein",
+    "chow mein",
+    "pasta",
+    "udon",
+    "ramen",
+    "spaghetti",
+    "alphabetti",
+    "macaroni",
+    "pasta"
+  ],
+  "date_inserted": {
+    "$date": "2022-04-27T01:44:59.057Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac5"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "dumpling"
+  ],
+  "synonyms": [
+    "won ton",
+    "wonton",
+    "matzo ball",
+    "gnocchi",
+    "matzah ball",
+    "pierogi"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac4"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "pie",
+    "tart",
+    "cobbler"
+  ],
+  "editable": false
+}]

--- a/data/synonyms/whatscooking.menu_synonyms_id.json
+++ b/data/synonyms/whatscooking.menu_synonyms_id.json
@@ -1,0 +1,110 @@
+[{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac3"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "shawarma",
+    "gyros"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "617f3b42ade8e71c16489dbe"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "burger",
+    "burgers",
+    "hamburger",
+    "hamburgers",
+    "cheeseburger",
+    "cheeseburgers"
+  ],
+  "date_inserted": null,
+  "date_updated": {
+    "$date": "2021-11-15T00:33:50.573Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "6268a01b5899f60be615cb66"
+  },
+  "input": [
+    "noodles"
+  ],
+  "mappingType": "explicit",
+  "synonyms": [
+    "lo mein",
+    "chow mein",
+    "pasta",
+    "udon",
+    "ramen",
+    "spaghetti",
+    "alphabetti",
+    "macaroni",
+    "pasta"
+  ],
+  "date_inserted": {
+    "$date": "2022-04-27T01:44:59.057Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac4"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "pie",
+    "tart",
+    "cobbler"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b7d834053fed8281c1ac6"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "pasta"
+  ],
+  "synonyms": [
+    "spaghetti",
+    "macaroni",
+    "fettuccine",
+    "cappellini",
+    "ravioli",
+    "rigatoni",
+    "linguine",
+    "penne",
+    "ziti",
+    "tortellini",
+    "tagliatelle",
+    "lasagna",
+    "lasagne",
+    "manicotti"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac5"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "dumpling"
+  ],
+  "synonyms": [
+    "won ton",
+    "wonton",
+    "matzo ball",
+    "gnocchi",
+    "matzah ball",
+    "pierogi"
+  ],
+  "editable": false
+}]

--- a/data/synonyms/whatscooking.menu_synonyms_jp.json
+++ b/data/synonyms/whatscooking.menu_synonyms_jp.json
@@ -1,0 +1,93 @@
+[{
+  "_id": {
+    "$oid": "617f3b42ade8e71c16489dbe"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "バーガー",
+    "burger",
+    "ハンバーガー",
+    "hamburger",
+    "チーズバーガー"
+  ],
+  "date_inserted": null,
+  "date_updated": {
+    "$date": "2021-11-15T00:33:50.573Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b7d834053fed8281c1ac6"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "pasta"
+  ],
+  "synonyms": [
+    "スパゲッティ",
+    "スパゲティ",
+    "パスタ",
+    "ペンネ",
+    "すぱげてぃ",
+    "すぱげってぃ"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac3"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "寿司",
+    "鮨",
+    "すし"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "6268a01b5899f60be615cb66"
+  },
+  "input": [
+    "イタリアン"
+  ],
+  "mappingType": "explicit",
+  "synonyms": [
+    "スパゲッティ",
+    "パスタ"
+  ],
+  "date_inserted": {
+    "$date": "2022-04-27T01:44:59.057Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac5"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "中華"
+  ],
+  "synonyms": [
+    "　",
+    "麻婆豆腐",
+    "餃子",
+    "四川料理",
+    "上海料理"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac4"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "パイ",
+    "タルト"
+  ],
+  "editable": false
+}]

--- a/data/synonyms/whatscooking.menu_synonyms_th.json
+++ b/data/synonyms/whatscooking.menu_synonyms_th.json
@@ -1,0 +1,110 @@
+[{
+  "_id": {
+    "$oid": "617f3b42ade8e71c16489dbe"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "burger",
+    "burgers",
+    "hamburger",
+    "hamburgers",
+    "cheeseburger",
+    "cheeseburgers"
+  ],
+  "date_inserted": null,
+  "date_updated": {
+    "$date": "2021-11-15T00:33:50.573Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b7d834053fed8281c1ac6"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "pasta"
+  ],
+  "synonyms": [
+    "spaghetti",
+    "macaroni",
+    "fettuccine",
+    "cappellini",
+    "ravioli",
+    "rigatoni",
+    "linguine",
+    "penne",
+    "ziti",
+    "tortellini",
+    "tagliatelle",
+    "lasagna",
+    "lasagne",
+    "manicotti"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac3"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "shawarma",
+    "gyros"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "6268a01b5899f60be615cb66"
+  },
+  "input": [
+    "noodles"
+  ],
+  "mappingType": "explicit",
+  "synonyms": [
+    "lo mein",
+    "chow mein",
+    "pasta",
+    "udon",
+    "ramen",
+    "spaghetti",
+    "alphabetti",
+    "macaroni",
+    "pasta"
+  ],
+  "date_inserted": {
+    "$date": "2022-04-27T01:44:59.057Z"
+  },
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac5"
+  },
+  "mappingType": "explicit",
+  "input": [
+    "dumpling"
+  ],
+  "synonyms": [
+    "won ton",
+    "wonton",
+    "matzo ball",
+    "gnocchi",
+    "matzah ball",
+    "pierogi"
+  ],
+  "editable": false
+},
+{
+  "_id": {
+    "$oid": "613b4ad34053fed8281c1ac4"
+  },
+  "mappingType": "equivalent",
+  "synonyms": [
+    "pie",
+    "tart",
+    "cobbler"
+  ],
+  "editable": false
+}]

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -24,7 +24,7 @@ const SearchBar = ({
   // if (searchTerm === "") setShowSuggestions(false);
 
   const Suggestions_AC_Endpoint =
-    "https://us-east-1.aws.data.mongodb-api.com/app/whatscooking-agtge/endpoint/restaurants/getRestaurantsAutocomplete";
+    "https://ap-southeast-1.aws.data.mongodb-api.com/app/application-1-rgjfz/endpoint/restaurants/getRestaurantsAutocomplete";
   
   const { t } = useTranslation();
 
@@ -33,7 +33,7 @@ const SearchBar = ({
     let autocomplete_names_endpoint = Suggestions_AC_Endpoint;
     if (searchTerm) {
       autocomplete_names_endpoint =
-        autocomplete_names_endpoint + `?restname=${searchTerm}`;
+        autocomplete_names_endpoint + `?restname=${searchTerm}&locale=${t('locale')}`;
     }
     try {
       let restaurants = await (await fetch(autocomplete_names_endpoint)).json();

--- a/src/hooks/useHomeFetch.js
+++ b/src/hooks/useHomeFetch.js
@@ -94,11 +94,12 @@ export const useHomeFetch = () => {
       stars: stars,
       borough: borough,
       cuisine: cuisine,
-      collection_name: t('locale'),
+      locale: t('locale'),
       lng: lng,
       lat: lat,
     };
     axios.post(GetFacetsEndpoint, facetData).then((res) => {
+      console.log()
       let count = res.data.results[0].count.lowerBound; // facet
       setFacetOverallCount(count);
       setCuisineBuckets(res.data.results[0].facet.cuisineFacet.buckets);

--- a/src/hooks/useHomeFetch.js
+++ b/src/hooks/useHomeFetch.js
@@ -65,7 +65,7 @@ export const useHomeFetch = () => {
       borough: borough,
       cuisine: cuisine,
       stars: stars,
-      collection_name: t('collection_name'),
+      locale: t('locale'),
       lng: lng,
       lat: lat,
     };
@@ -94,7 +94,7 @@ export const useHomeFetch = () => {
       stars: stars,
       borough: borough,
       cuisine: cuisine,
-      collection_name: t('collection_name'),
+      collection_name: t('locale'),
       lng: lng,
       lat: lat,
     };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -11,5 +11,5 @@
     "functionScore": "Function Score",
     "synonyms": "Synonyms",
     "dataAndIndexes": "Data & Indexes",
-    "collection_name": "restaurants"
+    "locale": "en"
 }

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -11,6 +11,5 @@
     "functionScore": "Skor Function",
     "synonyms": "Sinonim",
     "dataAndIndexes": "Data & Indeks",
-    "collection_name": "restaurants_id",
-    "synonyms_name": "menu_synonyms_id"
+    "synonyms_name": "id"
 }

--- a/src/locales/jp/translation.json
+++ b/src/locales/jp/translation.json
@@ -11,6 +11,5 @@
     "functionScore": "ファンクションスコア",
     "synonyms": "類似語",
     "dataAndIndexes": "データとインデックス",
-    "collection_name": "restaurants_jp",
-    "synonyms_name": "menu_synonyms_jp"
+    "locale": "jp"
 }

--- a/src/locales/jp/translation.json
+++ b/src/locales/jp/translation.json
@@ -11,5 +11,6 @@
     "functionScore": "ファンクションスコア",
     "synonyms": "類似語",
     "dataAndIndexes": "データとインデックス",
-    "collection_name": "restaurants_jp"
+    "collection_name": "restaurants_jp",
+    "synonyms_name": "menu_synonyms_jp"
 }

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -11,5 +11,6 @@
     "functionScore": "TODO",
     "synonyms": "TODO",
     "dataAndIndexes": "TODO",
-    "collection_name": "restaurants_th"
+    "collection_name": "restaurants_th",
+    "synonyms_name": "menu_synonyms_th"
 }

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -11,6 +11,5 @@
     "functionScore": "TODO",
     "synonyms": "TODO",
     "dataAndIndexes": "TODO",
-    "collection_name": "restaurants_th",
-    "synonyms_name": "menu_synonyms_th"
+    "locale": "th"
 }

--- a/src/pages/SynonymsPage.js
+++ b/src/pages/SynonymsPage.js
@@ -24,7 +24,7 @@ const SynonymsPage = () => {
   const getSynonyms = async () => {
     let storedSynonyms = await (
       await fetch(
-        "https://ap-southeast-1.aws.data.mongodb-api.com/app/application-1-rgjfz/endpoint/synonyms/getFoodSynonyms?synonyms="+ t('synonyms_name')
+        "https://ap-southeast-1.aws.data.mongodb-api.com/app/application-1-rgjfz/endpoint/synonyms/getFoodSynonyms?synonyms="+ t('synonyms_name') + "&locale=" + t('locale')
       )
     ).json();
     setLoadedSynonyms(storedSynonyms.foodSynonyms);


### PR DESCRIPTION
We specified collection_name for each language like restaurants_id, but we need to integrate the same language supports for menu_synonyms collection, too. So I changed parameter from collection_name to locale to reduce the number of parameters and keep architecture simple.